### PR TITLE
開発用の記事ライブプレビューを追加

### DIFF
--- a/app/api/news/preview/route.ts
+++ b/app/api/news/preview/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server';
+import { getArticleData } from '@/lib/news';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: Request) {
+  if (process.env.NODE_ENV !== 'development') {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const slug = searchParams.get('slug');
+
+  if (!slug) {
+    return NextResponse.json(
+      { error: 'Missing slug query parameter' },
+      {
+        status: 400,
+        headers: {
+          'Cache-Control': 'no-store',
+        },
+      },
+    );
+  }
+
+  const article = getArticleData(slug);
+
+  if (!article) {
+    return NextResponse.json(
+      { error: 'Article not found' },
+      {
+        status: 404,
+        headers: {
+          'Cache-Control': 'no-store',
+        },
+      },
+    );
+  }
+
+  return NextResponse.json(article, {
+    headers: {
+      'Cache-Control': 'no-store',
+    },
+  });
+}

--- a/app/news/[slug]/PreviewArticleClient.tsx
+++ b/app/news/[slug]/PreviewArticleClient.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import type { ArticleData } from '@/lib/news';
+import ArticleHeader from '../_components/ArticleHeader';
+import ArticleMarkdown from '../_components/ArticleMarkdown';
+
+interface PreviewArticleClientProps {
+  initialArticle: ArticleData | null;
+  slug: string;
+}
+
+type PreviewState =
+  | { status: 'loading'; article: ArticleData | null; message?: string }
+  | { status: 'ready'; article: ArticleData }
+  | { status: 'not-found'; article: null; message: string }
+  | { status: 'error'; article: ArticleData | null; message: string };
+
+function initialState(article: ArticleData | null): PreviewState {
+  if (article) {
+    return { status: 'ready', article };
+  }
+  return {
+    status: 'loading',
+    article: null,
+    message: '記事ファイルの生成を待っています。',
+  };
+}
+
+export default function PreviewArticleClient({ initialArticle, slug }: PreviewArticleClientProps) {
+  const [state, setState] = useState<PreviewState>(() => initialState(initialArticle));
+  const lastSerialized = useRef(initialArticle ? JSON.stringify(initialArticle) : null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadArticle() {
+      try {
+        const response = await fetch(`/api/news/preview?slug=${encodeURIComponent(slug)}`, {
+          cache: 'no-store',
+        });
+
+        if (cancelled) {
+          return;
+        }
+
+        if (response.status === 404) {
+          setState({
+            status: 'not-found',
+            article: null,
+            message: '対象の記事がまだ見つかりません。Markdown を保存すると自動で反映されます。',
+          });
+          lastSerialized.current = null;
+          return;
+        }
+
+        if (!response.ok) {
+          throw new Error(`Preview API returned ${response.status}`);
+        }
+
+        const nextArticle = (await response.json()) as ArticleData;
+        const serialized = JSON.stringify(nextArticle);
+
+        if (lastSerialized.current === serialized) {
+          setState((current) => {
+            if (current.status === 'ready') {
+              return current;
+            }
+            return { status: 'ready', article: nextArticle };
+          });
+          return;
+        }
+
+        lastSerialized.current = serialized;
+        setState({ status: 'ready', article: nextArticle });
+      } catch {
+        setState((current) => ({
+          status: 'error',
+          article: current.article ?? initialArticle,
+          message: 'プレビューの更新に失敗しました。次回ポーリングで再試行します。',
+        }));
+      }
+    }
+
+    loadArticle();
+    const intervalId = window.setInterval(loadArticle, 1000);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+    };
+  }, [initialArticle, slug]);
+
+  const article = state.article;
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm font-medium text-emerald-800">
+        開発用ライブプレビューです。`app/news/articles/{slug}.md` を保存すると数秒以内に再読込されます。
+      </div>
+
+      {state.status === 'not-found' && (
+        <div className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm font-medium text-amber-800">
+          {state.message}
+        </div>
+      )}
+
+      {state.status === 'error' && (
+        <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-medium text-rose-800">
+          {state.message}
+        </div>
+      )}
+
+      {state.status === 'loading' && !article && (
+        <div className="rounded-2xl border border-slate-200 bg-white px-4 py-6 text-center text-sm font-medium text-slate-600">
+          {state.message}
+        </div>
+      )}
+
+      {article && (
+        <>
+          <ArticleHeader article={article} />
+          <ArticleMarkdown content={article.content} />
+        </>
+      )}
+    </div>
+  );
+}

--- a/app/news/[slug]/page.tsx
+++ b/app/news/[slug]/page.tsx
@@ -1,11 +1,8 @@
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-import remarkMath from 'remark-math';
-import rehypeKatex from 'rehype-katex';
 import 'katex/dist/katex.min.css';
-import CodeBlock from './CodeBlock';
+import ArticleHeader from '../_components/ArticleHeader';
+import ArticleMarkdown from '../_components/ArticleMarkdown';
 import { getArticleData, getSortedArticlesData } from '@/lib/news';
 
 export const dynamic = 'force-static';
@@ -41,84 +38,18 @@ export default async function ArticlePage({ params }: { params: Promise<{ slug: 
   return (
     <div className="min-h-screen bg-slate-50 text-slate-900 font-sans p-4 md:p-8 lg:p-16 selection:bg-emerald-200">
       <div className="max-w-3xl mx-auto space-y-6">
-                
-        {/* Article Header */}
-        <header className="space-y-6 flex flex-col items-start">
-          <div className="flex flex-wrap items-center gap-3">
-            <time dateTime={articleData.date} className="inline-flex items-center gap-2 text-sm font-bold text-emerald-600 bg-emerald-50 px-3 py-1.5 rounded-full border border-emerald-100">
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth="2">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-              </svg>
-              {new Date(articleData.date).toLocaleDateString('ja-JP')}
-            </time>
-            {articleData.author && (
-              <div className="inline-flex items-center gap-2 text-sm font-bold text-slate-600 bg-slate-100 px-3 py-1.5 rounded-full border border-slate-200">
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth="2">
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-                </svg>
-                {articleData.author}
-              </div>
-            )}
+        {process.env.NODE_ENV === 'development' && (
+          <div className="flex justify-end">
+            <Link
+              href={`/news/preview/${slug}`}
+              className="rounded-full border border-emerald-200 bg-emerald-50 px-4 py-2 text-sm font-bold text-emerald-700 transition-colors hover:bg-emerald-100"
+            >
+              開発用ライブプレビューを開く
+            </Link>
           </div>
-          <h1 className="text-3xl md:text-4xl lg:text-5xl font-extrabold tracking-tight text-slate-900 leading-tight">
-            {articleData.title}
-          </h1>
-        </header>
-
-        {/* Markdown Content rendered via react-markdown */}
-        <article className="prose prose-slate prose-emerald md:prose-lg max-w-none bg-white p-6 md:p-10 rounded-2xl shadow-sm border border-slate-200">
-          <ReactMarkdown 
-            remarkPlugins={[remarkGfm, remarkMath]}
-            rehypePlugins={[rehypeKatex]}
-            components={{
-              // Tailwind Typographyがない場合のフォールバック用カスタムスタイリング
-              h1: ({node, ...props}) => <h1 className="text-2xl md:text-3xl font-extrabold text-slate-900 mt-6 mb-4 pb-3 border-b-2 border-slate-100" {...props} />,
-              h2: ({node, ...props}) => <h2 className="text-xl md:text-2xl font-bold text-slate-900 mt-8 mb-3 pb-2 border-b border-slate-100" {...props} />,
-              h3: ({node, ...props}) => <h3 className="text-lg md:text-xl font-bold text-slate-900 mt-6 mb-3 flex items-center gap-2" {...props}><span className="w-1.5 h-6 bg-emerald-500 rounded-full inline-block"></span>{props.children}</h3>,
-              p: ({node, ...props}) => <p className="leading-relaxed text-slate-700 font-medium mb-5 text-base" {...props} />,
-              a: ({ node, href, children, ...props }) => {
-                const linkClass = "text-emerald-600 hover:text-emerald-700 underline underline-offset-4 decoration-emerald-200 hover:decoration-emerald-500 transition-all font-bold";
-                if (!href) {
-                  return <span className={linkClass} {...props}>{children}</span>;
-                }
-                const isExternal = /^https?:\/\//.test(href);
-                if (isExternal) {
-                  return <a href={href} className={linkClass} target="_blank" rel="noopener noreferrer" {...props}>{children}</a>;
-                }
-                return <Link href={href} className={linkClass} {...props}>{children}</Link>;
-              },
-              ul: ({node, ...props}) => <ul className="list-disc list-outside ml-6 mb-5 space-y-1.5 text-slate-700 font-medium marker:text-emerald-500" {...props} />,
-              ol: ({node, ...props}) => <ol className="list-decimal list-outside ml-6 mb-5 space-y-1.5 text-slate-700 font-medium font-mono marker:text-emerald-600" {...props} />,
-              li: ({node, ...props}) => <li className="pl-1 leading-relaxed" {...props} />,
-              blockquote: ({node, ...props}) => <blockquote className="border-l-4 border-emerald-400 pl-4 py-1.5 my-4 bg-emerald-50/50 rounded-r-xl italic text-slate-600 font-medium" {...props} />,
-              code: ({node, className, children, ref, ...props}) => {
-                const match = /language-(\w+)/.exec(className || '');
-                return match ? (
-                  <CodeBlock language={match[1]}>
-                    {children}
-                  </CodeBlock>
-                ) : (
-                  <code className="bg-slate-100 text-slate-800 px-2 py-1 rounded-md text-sm font-mono border border-slate-200 break-words" {...props}>
-                    {children}
-                  </code>
-                )
-              },
-              img: ({node, alt, ...props}) => (
-                <span className="block w-fit max-w-full my-10 mx-auto rounded-2xl overflow-hidden shadow-md border border-slate-200">
-                  <img 
-                    className="max-w-full w-auto h-auto object-cover !m-0" 
-                    alt={alt || 'Article image'} 
-                    {...props} 
-                  />
-                </span>
-              ),
-              hr: ({node, ...props}) => <hr className="my-10 border-t-2 border-slate-100 border-dashed" {...props} />
-            }}
-          >
-            {articleData.content}
-          </ReactMarkdown>
-        </article>
-
+        )}
+        <ArticleHeader article={articleData} />
+        <ArticleMarkdown content={articleData.content} />
       </div>
     </div>
   );

--- a/app/news/[slug]/preview-designdoc.md
+++ b/app/news/[slug]/preview-designdoc.md
@@ -1,0 +1,192 @@
+# ニュース記事ライブプレビュー実装方針
+
+## 目的
+
+- `app/news/articles/*.md` を編集しながら、`npm run dev` 中のブラウザでほぼ即時に反映を確認できるようにする
+- 既存の `/news`、`/news/[slug]`、トップページ、`sitemap.xml` の本番向け静的生成フローは維持する
+- Cloudflare Pages での `next build` / ホスティング時には、このプレビュー機構が挙動や成果物に影響しないようにする
+
+## 現状整理
+
+- 記事本体は `app/news/articles/*.md`
+- 読み込みは `lib/news.ts` の `fs.readFileSync` + `gray-matter`
+- 一覧は `getSortedArticlesData()`
+- 詳細は `getArticleData(id)`
+- 詳細ページ `app/news/[slug]/page.tsx` は `generateStaticParams()` + `dynamic = 'force-static'`
+
+このため、本番要件には合っているが、Markdown ファイル更新を Next.js の通常 HMR が必ずしも監視しない。特に `force-static` な詳細ページは、開発中に「保存した Markdown が自動で画面へ反映される」体験に向かない。
+
+## 方針
+
+### 1. 本番ルートはそのまま残す
+
+- `app/news/page.tsx`
+- `app/page.tsx`
+- `app/news/[slug]/page.tsx`
+- `app/sitemap.xml/route.ts`
+
+これらは今の Markdown 読み込みロジックを使い続ける。
+本番では従来どおり、ビルド時点の `.md` 内容で静的生成する。
+
+### 2. 開発専用のプレビュー経路を追加する
+
+追加候補:
+
+- `app/news/preview/[slug]/page.tsx`
+- `app/api/news/preview/route.ts`
+
+役割:
+
+- `/news/preview/[slug]` は開発中の記事確認専用ページ
+- `/api/news/preview?slug=...` は最新の Markdown を都度 `fs` で読み直して JSON を返す
+
+この preview ルートは以下にする:
+
+- `dynamic = 'force-dynamic'`
+- `fetch(..., { cache: 'no-store' })` または route handler 側で no-store を明示
+- `process.env.NODE_ENV !== 'development'` では 404 もしくはアクセス不可にする
+
+これにより Cloudflare Pages 本番では preview 機構は実質無効化される。
+
+## 反映方式
+
+### 推奨: dev 限定のクライアント再取得
+
+`/news/preview/[slug]` は client component を 1 つ噛ませ、一定間隔で preview API を再取得する。
+
+- 初回表示時に記事を取得
+- 以後 1000ms 前後で再取得
+- 差分があれば再描画
+
+これなら Next.js の HMR が Markdown ファイル自体を監視しなくても、保存した内容がブラウザへ自動反映される。
+
+補足:
+
+- これは厳密には「React Fast Refresh」ではなく「live preview / auto refresh」
+- ただし目的である「記事を書きながら保存内容をすぐ確認する」は満たせる
+
+### 代替案: `fs.watch` / SSE
+
+よりリアルタイムにしたい場合は:
+
+- `app/api/news/preview-events/route.ts`
+- `fs.watch(app/news/articles)`
+- `EventSource`
+
+で push 通知も可能。
+ただし実装が重く、開発用としては polling のほうが単純で壊れにくい。
+最初の実装は polling を推奨する。
+
+## ロジック分割案
+
+`lib/news.ts` を少し整理する。
+
+### 追加したい関数
+
+- `getAllArticleSlugs()`
+- `getArticleMetaFromFile(fileName: string)`
+- `getArticleData(id: string, options?: { preview?: boolean })`
+
+ただし preview 用に特殊処理を増やしすぎる必要はない。
+基本は既存の `getSortedArticlesData()` / `getArticleData()` をそのまま route handler から呼べばよい。
+
+必要なのは「どこで static に読むか」「どこで dynamic / no-store に読むか」を分離すること。
+
+## 画面構成案
+
+### `app/news/preview/[slug]/page.tsx`
+
+- 開発専用ページ
+- slug を受け取る
+- `process.env.NODE_ENV !== 'development'` なら `notFound()`
+- preview client component を描画
+
+### `app/news/[slug]/PreviewArticleClient.tsx`
+
+- `useEffect` で preview API を定期取得
+- 取得した `title`, `date`, `author`, `excerpt`, `content` を state 管理
+- Markdown 描画部分は既存の `app/news/[slug]/page.tsx` と同じ `ReactMarkdown` / `CodeBlock` 設定を使い回す
+
+重複を避けるため、本文表示部分は共通 component 化してよい。
+
+例:
+
+- `app/news/_components/ArticleMarkdown.tsx`
+- `app/news/_components/ArticleHeader.tsx`
+
+## API 仕様案
+
+### `GET /api/news/preview?slug={slug}`
+
+レスポンス例:
+
+```json
+{
+  "id": "2026-03-09-free-in-kanazawa",
+  "title": "記事タイトル",
+  "date": "2026-03-09",
+  "author": "Digitart",
+  "excerpt": "概要",
+  "content": "# 本文"
+}
+```
+
+要件:
+
+- `NODE_ENV !== 'development'` では 404
+- slug 未指定は 400
+- 記事なしは 404
+- `Cache-Control: no-store`
+
+## Cloudflare Pages への影響
+
+本番影響を避けるポイントは以下。
+
+- 既存の公開ルート `/news/[slug]` は引き続き静的生成
+- preview ルートは dev 以外で無効
+- sitemap には preview ルートを載せない
+- トップページや一覧ページの本番ロジックは変更しない
+
+つまり、Cloudflare Pages 上では今までどおり:
+
+- Markdown を追加
+- `next build`
+- 静的ページとして配信
+
+のまま運用できる。
+
+## 実装ステップ
+
+1. `app/news/preview/[slug]/page.tsx` を追加する
+2. `app/api/news/preview/route.ts` を追加する
+3. 既存詳細ページから Markdown 描画部分を共通 component に切り出す
+4. preview client component を作り、定期再取得で自動更新する
+5. 開発時だけ preview への導線を出す
+
+導線候補:
+
+- 通常記事ページの上部に `開発用プレビューを開く` リンクを dev 限定表示
+- 一覧ページで dev 時のみ `/news/preview/[slug]` への補助リンクを表示
+
+## 非推奨案
+
+### 既存 `/news/[slug]` を dev 時だけ dynamic に切り替える
+
+避けたい理由:
+
+- route segment config は静的に扱う前提が強い
+- 本番用ページと開発用ページの責務が混ざる
+- `generateStaticParams()` との関係が不明瞭になりやすい
+
+本番ルートと preview ルートを分けたほうが安全。
+
+## 結論
+
+採用方針は以下。
+
+- 公開用の `/news/[slug]` は今のまま static
+- 開発専用の `/news/preview/[slug]` を追加
+- preview は `force-dynamic` + `no-store` + 定期再取得
+- production / Cloudflare Pages では preview を無効化
+
+これが最も単純で、既存構成を壊さず、Markdown 執筆時の確認速度だけを改善できる。

--- a/app/news/_components/ArticleHeader.tsx
+++ b/app/news/_components/ArticleHeader.tsx
@@ -1,0 +1,34 @@
+import type { ArticleData } from '@/lib/news';
+
+interface ArticleHeaderProps {
+  article: Pick<ArticleData, 'title' | 'date' | 'author'>;
+}
+
+export default function ArticleHeader({ article }: ArticleHeaderProps) {
+  return (
+    <header className="space-y-6 flex flex-col items-start">
+      <div className="flex flex-wrap items-center gap-3">
+        <time
+          dateTime={article.date}
+          className="inline-flex items-center gap-2 text-sm font-bold text-emerald-600 bg-emerald-50 px-3 py-1.5 rounded-full border border-emerald-100"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth="2">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+          </svg>
+          {new Date(article.date).toLocaleDateString('ja-JP')}
+        </time>
+        {article.author && (
+          <div className="inline-flex items-center gap-2 text-sm font-bold text-slate-600 bg-slate-100 px-3 py-1.5 rounded-full border border-slate-200">
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth="2">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+            </svg>
+            {article.author}
+          </div>
+        )}
+      </div>
+      <h1 className="text-3xl md:text-4xl lg:text-5xl font-extrabold tracking-tight text-slate-900 leading-tight">
+        {article.title}
+      </h1>
+    </header>
+  );
+}

--- a/app/news/_components/ArticleMarkdown.tsx
+++ b/app/news/_components/ArticleMarkdown.tsx
@@ -1,0 +1,111 @@
+/* eslint-disable @next/next/no-img-element */
+
+import Link from 'next/link';
+import ReactMarkdown from 'react-markdown';
+import rehypeKatex from 'rehype-katex';
+import remarkGfm from 'remark-gfm';
+import remarkMath from 'remark-math';
+import CodeBlock from '../[slug]/CodeBlock';
+
+interface ArticleMarkdownProps {
+  content: string;
+}
+
+export default function ArticleMarkdown({ content }: ArticleMarkdownProps) {
+  return (
+    <article className="prose prose-slate prose-emerald md:prose-lg max-w-none bg-white p-6 md:p-10 rounded-2xl shadow-sm border border-slate-200">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm, remarkMath]}
+        rehypePlugins={[rehypeKatex]}
+        components={{
+          h1: ({ node, ...props }) => {
+            void node;
+            return <h1 className="text-2xl md:text-3xl font-extrabold text-slate-900 mt-6 mb-4 pb-3 border-b-2 border-slate-100" {...props} />;
+          },
+          h2: ({ node, ...props }) => {
+            void node;
+            return <h2 className="text-xl md:text-2xl font-bold text-slate-900 mt-8 mb-3 pb-2 border-b border-slate-100" {...props} />;
+          },
+          h3: ({ node, ...props }) => {
+            void node;
+            return (
+              <h3 className="text-lg md:text-xl font-bold text-slate-900 mt-6 mb-3 flex items-center gap-2" {...props}>
+                <span className="w-1.5 h-6 bg-emerald-500 rounded-full inline-block"></span>
+                {props.children}
+              </h3>
+            );
+          },
+          p: ({ node, ...props }) => {
+            void node;
+            return <p className="leading-relaxed text-slate-700 font-medium mb-5 text-base" {...props} />;
+          },
+          a: ({ node, href, children, ...props }) => {
+            void node;
+            const linkClass = 'text-emerald-600 hover:text-emerald-700 underline underline-offset-4 decoration-emerald-200 hover:decoration-emerald-500 transition-all font-bold';
+            if (!href) {
+              return (
+                <span className={linkClass} {...props}>
+                  {children}
+                </span>
+              );
+            }
+            const isExternal = /^https?:\/\//.test(href);
+            if (isExternal) {
+              return (
+                <a href={href} className={linkClass} target="_blank" rel="noopener noreferrer" {...props}>
+                  {children}
+                </a>
+              );
+            }
+            return (
+              <Link href={href} className={linkClass} {...props}>
+                {children}
+              </Link>
+            );
+          },
+          ul: ({ node, ...props }) => {
+            void node;
+            return <ul className="list-disc list-outside ml-6 mb-5 space-y-1.5 text-slate-700 font-medium marker:text-emerald-500" {...props} />;
+          },
+          ol: ({ node, ...props }) => {
+            void node;
+            return <ol className="list-decimal list-outside ml-6 mb-5 space-y-1.5 text-slate-700 font-medium font-mono marker:text-emerald-600" {...props} />;
+          },
+          li: ({ node, ...props }) => {
+            void node;
+            return <li className="pl-1 leading-relaxed" {...props} />;
+          },
+          blockquote: ({ node, ...props }) => {
+            void node;
+            return <blockquote className="border-l-4 border-emerald-400 pl-4 py-1.5 my-4 bg-emerald-50/50 rounded-r-xl italic text-slate-600 font-medium" {...props} />;
+          },
+          code: ({ node, className, children, ...props }) => {
+            void node;
+            const match = /language-(\w+)/.exec(className || '');
+            return match ? (
+              <CodeBlock language={match[1]}>{children}</CodeBlock>
+            ) : (
+              <code className="bg-slate-100 text-slate-800 px-2 py-1 rounded-md text-sm font-mono border border-slate-200 break-words" {...props}>
+                {children}
+              </code>
+            );
+          },
+          img: ({ node, alt, ...props }) => {
+            void node;
+            return (
+              <span className="block w-fit max-w-full my-10 mx-auto rounded-2xl overflow-hidden shadow-md border border-slate-200">
+                <img className="max-w-full w-auto h-auto object-cover !m-0" alt={alt || 'Article image'} {...props} />
+              </span>
+            );
+          },
+          hr: ({ node, ...props }) => {
+            void node;
+            return <hr className="my-10 border-t-2 border-slate-100 border-dashed" {...props} />;
+          },
+        }}
+      >
+        {content}
+      </ReactMarkdown>
+    </article>
+  );
+}

--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -63,6 +63,13 @@ export default function NewsPage() {
                         {excerpt}
                       </p>
                     )}
+                    {process.env.NODE_ENV === 'development' && (
+                      <div className="pt-1">
+                        <span className="inline-flex items-center rounded-full border border-emerald-200 bg-emerald-50 px-2.5 py-1 text-xs font-bold text-emerald-700">
+                          Preview: /news/preview/{id}
+                        </span>
+                      </div>
+                    )}
                   </div>
                     
                   {/* ボタン部分 (右寄せ or 下寄せ) */}

--- a/app/news/preview/[slug]/page.tsx
+++ b/app/news/preview/[slug]/page.tsx
@@ -1,0 +1,23 @@
+import { notFound } from 'next/navigation';
+import 'katex/dist/katex.min.css';
+import PreviewArticleClient from '../../[slug]/PreviewArticleClient';
+import { getArticleData } from '@/lib/news';
+
+export const dynamic = 'force-dynamic';
+
+export default async function PreviewArticlePage({ params }: { params: Promise<{ slug: string }> }) {
+  if (process.env.NODE_ENV !== 'development') {
+    notFound();
+  }
+
+  const { slug } = await params;
+  const articleData = getArticleData(slug);
+
+  return (
+    <div className="min-h-screen bg-slate-50 text-slate-900 font-sans p-4 md:p-8 lg:p-16 selection:bg-emerald-200">
+      <div className="max-w-3xl mx-auto">
+        <PreviewArticleClient initialArticle={articleData} slug={slug} />
+      </div>
+    </div>
+  );
+}

--- a/lib/news.ts
+++ b/lib/news.ts
@@ -5,7 +5,19 @@ import matter from 'gray-matter';
 // src配下やapp配下のarticlesディレクトリを指定
 const articlesDirectory = path.join(process.cwd(), 'app', 'news', 'articles');
 
-export function getSortedArticlesData() {
+export interface ArticleMeta {
+  id: string;
+  title: string;
+  date: string;
+  excerpt?: string;
+  author?: string;
+}
+
+export interface ArticleData extends ArticleMeta {
+  content: string;
+}
+
+export function getSortedArticlesData(): ArticleMeta[] {
   // ディレクトリがない（最初）場合は空配列を返す
   if (!fs.existsSync(articlesDirectory)) {
     return [];
@@ -46,7 +58,7 @@ export function getSortedArticlesData() {
   });
 }
 
-export function getArticleData(id: string) {
+export function getArticleData(id: string): ArticleData | null {
   const fullPath = path.join(articlesDirectory, `${id}.md`);
   if (!fs.existsSync(fullPath)) {
     return null;


### PR DESCRIPTION
## 概要
- 開発時専用のニュース記事プレビュールートと preview API を追加し、ポーリングで Markdown 更新を自動反映するようにしました
- 公開用の静的記事ページとプレビューページで、記事ヘッダーと Markdown 描画 UI を共通化しました
- プレビュー方針を設計メモに追記し、本番のニュースルートは静的生成のまま維持しています