### PR TITLE
fix: ページタイトル文修正とデザインの統一

### DIFF
--- a/app/about/data/page.tsx
+++ b/app/about/data/page.tsx
@@ -87,14 +87,17 @@ export default function DataPage() {
   return (
     <div className="bg-white">
       {/* Hero */}
-      <section className="pt-32 pb-20 px-6 bg-gradient-to-br from-teal-400 via-emerald-600 to-green-600 text-white">
-        <div className="max-w-6xl mx-auto">
+      <section className="pt-32 pb-20 px-6 bg-gradient-to-br from-emerald-500 via-green-600 to-teal-600 text-white relative overflow-hidden">
+        <div className="absolute inset-0 opacity-10">
+          <div className="absolute inset-0 bg-[url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNjAiIGhlaWdodD0iNjAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PHBhdHRlcm4gaWQ9ImdyaWQiIHdpZHRoPSI2MCIgaGVpZ2h0PSI2MCIgcGF0dGVyblVuaXRzPSJ1c2VyU3BhY2VPblVzZSI+PHBhdGggZD0iTSAxMCAwIEwgMCAwIDAgMTAiIGZpbGw9Im5vbmUiIHN0cm9rZT0id2hpdGUiIHN0cm9rZS13aWR0aD0iMSIgb3BhY2l0eT0iMC4zIi8+PC9wYXR0ZXJuPjwvZGVmcz48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSJ1cmwoI2dyaWQpIi8+PC9zdmc+')] " />
+        </div>
+        <div className="max-w-6xl mx-auto relative z-10">
           <Link
             href="/about"
             className="inline-flex items-center gap-2 text-white/80 hover:text-white mb-8 transition-colors"
           >
             <ArrowLeft className="w-4 h-4" />
-            ABOUT US
+            戻る
           </Link>
           <motion.h1
             initial={{ opacity: 0, y: 30 }}
@@ -103,7 +106,7 @@ export default function DataPage() {
             className="text-5xl md:text-7xl mb-4"
             style={{ fontWeight: 700 }}
           >
-            Data
+            活動データ
           </motion.h1>
           <motion.p
             initial={{ opacity: 0, y: 20 }}

--- a/app/about/events/page.tsx
+++ b/app/about/events/page.tsx
@@ -219,7 +219,7 @@ export default function EventsPage() {
             className="inline-flex items-center gap-2 text-white/80 hover:text-white mb-8 transition-colors"
           >
             <ArrowLeft className="w-4 h-4" />
-            ABOUT US
+            戻る
           </Link>
           <motion.h1
             initial={{ opacity: 0, y: 30 }}
@@ -228,7 +228,7 @@ export default function EventsPage() {
             className="text-5xl md:text-7xl mb-4"
             style={{ fontWeight: 700 }}
           >
-            Events
+          年間行事
           </motion.h1>
           <motion.p
             initial={{ opacity: 0, y: 20 }}
@@ -236,7 +236,7 @@ export default function EventsPage() {
             transition={{ duration: 0.8, delay: 0.2 }}
             className="text-xl text-white/90"
           >
-            年間スケジュール
+            一年を通して実施されるイベントをご紹介
           </motion.p>
         </div>
       </section>
@@ -275,7 +275,7 @@ export default function EventsPage() {
               className="text-3xl md:text-4xl text-gray-900"
               style={{ fontWeight: 700 }}
             >
-              Annual Schedule
+              スケジュール
             </h2>
           </motion.div>
 

--- a/app/about/history/page.tsx
+++ b/app/about/history/page.tsx
@@ -52,14 +52,17 @@ export default function HistoryPage() {
   return (
     <div className="bg-white">
       {/* Hero */}
-      <section className="pt-32 pb-20 px-6 bg-gradient-to-br from-emerald-400 via-green-600 to-teal-600 text-white">
-        <div className="max-w-6xl mx-auto">
+      <section className="pt-32 pb-20 px-6 bg-gradient-to-br from-emerald-500 via-green-600 to-teal-600 text-white relative overflow-hidden">
+        <div className="absolute inset-0 opacity-10">
+          <div className="absolute inset-0 bg-[url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNjAiIGhlaWdodD0iNjAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PHBhdHRlcm4gaWQ9ImdyaWQiIHdpZHRoPSI2MCIgaGVpZ2h0PSI2MCIgcGF0dGVyblVuaXRzPSJ1c2VyU3BhY2VPblVzZSI+PHBhdGggZD0iTSAxMCAwIEwgMCAwIDAgMTAiIGZpbGw9Im5vbmUiIHN0cm9rZT0id2hpdGUiIHN0cm9rZS13aWR0aD0iMSIgb3BhY2l0eT0iMC4zIi8+PC9wYXR0ZXJuPjwvZGVmcz48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSJ1cmwoI2dyaWQpIi8+PC9zdmc+')] " />
+        </div>
+        <div className="max-w-6xl mx-auto relative z-10">
           <Link
             href="/about"
             className="inline-flex items-center gap-2 text-white/80 hover:text-white mb-8 transition-colors"
           >
             <ArrowLeft className="w-4 h-4" />
-            ABOUT US
+            戻る
           </Link>
           <motion.h1
             initial={{ opacity: 0, y: 30 }}
@@ -68,7 +71,7 @@ export default function HistoryPage() {
             className="text-5xl md:text-7xl mb-4"
             style={{ fontWeight: 700 }}
           >
-            History
+            団体の歩み
           </motion.h1>
           <motion.p
             initial={{ opacity: 0, y: 20 }}

--- a/app/about/supporter/page.tsx
+++ b/app/about/supporter/page.tsx
@@ -75,14 +75,17 @@ export default function SupporterPage() {
   return (
     <div className="bg-white">
       {/* Hero */}
-      <section className="pt-32 pb-20 px-6 bg-gradient-to-br from-lime-400 via-green-600 to-emerald-600 text-white">
-        <div className="max-w-6xl mx-auto">
+      <section className="pt-32 pb-20 px-6 bg-gradient-to-br from-emerald-500 via-green-600 to-teal-600 text-white relative overflow-hidden">
+        <div className="absolute inset-0 opacity-10">
+          <div className="absolute inset-0 bg-[url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNjAiIGhlaWdodD0iNjAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PHBhdHRlcm4gaWQ9ImdyaWQiIHdpZHRoPSI2MCIgaGVpZ2h0PSI2MCIgcGF0dGVyblVuaXRzPSJ1c2VyU3BhY2VPblVzZSI+PHBhdGggZD0iTSAxMCAwIEwgMCAwIDAgMTAiIGZpbGw9Im5vbmUiIHN0cm9rZT0id2hpdGUiIHN0cm9rZS13aWR0aD0iMSIgb3BhY2l0eT0iMC4zIi8+PC9wYXR0ZXJuPjwvZGVmcz48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSJ1cmwoI2dyaWQpIi8+PC9zdmc+')] " />
+        </div>
+        <div className="max-w-6xl mx-auto relative z-10">
           <Link
             href="/about"
             className="inline-flex items-center gap-2 text-white/80 hover:text-white mb-8 transition-colors"
           >
             <ArrowLeft className="w-4 h-4" />
-            ABOUT US
+            戻る
           </Link>
           <motion.h1
             initial={{ opacity: 0, y: 30 }}
@@ -91,7 +94,7 @@ export default function SupporterPage() {
             className="text-5xl md:text-7xl mb-4"
             style={{ fontWeight: 700 }}
           >
-            Supporter
+            幹部紹介
           </motion.h1>
           <motion.p
             initial={{ opacity: 0, y: 20 }}

--- a/app/about/works/page.tsx
+++ b/app/about/works/page.tsx
@@ -72,41 +72,50 @@ export default function WorksPage() {
   return (
     <div className="bg-white">
       {/* Hero */}
-      <section className="pt-32 pb-20 px-6 bg-white border-b border-slate-100">
-        <div className="max-w-6xl mx-auto text-center">
+      <section className="pt-32 pb-20 px-6 bg-gradient-to-br from-emerald-500 via-green-600 to-teal-600 text-white relative overflow-hidden">
+        <div className="absolute inset-0 opacity-10">
+          <div className="absolute inset-0 bg-[url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNjAiIGhlaWdodD0iNjAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PHBhdHRlcm4gaWQ9ImdyaWQiIHdpZHRoPSI2MCIgaGVpZ2h0PSI2MCIgcGF0dGVyblVuaXRzPSJ1c2VyU3BhY2VPblVzZSI+PHBhdGggZD0iTSAxMCAwIEwgMCAwIDAgMTAiIGZpbGw9Im5vbmUiIHN0cm9rZT0id2hpdGUiIHN0cm9rZS13aWR0aD0iMSIgb3BhY2l0eT0iMC4zIi8+PC9wYXR0ZXJuPjwvZGVmcz48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSJ1cmwoI2dyaWQpIi8+PC9zdmc+')] " />
+        </div>
+        <div className="max-w-6xl mx-auto relative z-10">
           <Link
             href="/about"
-            className="inline-flex items-center gap-2 text-slate-400 hover:text-[#8cc63f] mb-8 transition-colors font-bold tracking-wider text-sm"
+            className="inline-flex items-center gap-2 text-white/80 hover:text-white mb-8 transition-colors"
           >
             <ArrowLeft className="w-4 h-4" />
-            ABOUT US
+            戻る
           </Link>
-          <motion.div
+          <motion.h1
             initial={{ opacity: 0, y: 30 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.8 }}
+            className="text-5xl md:text-7xl mb-4"
+            style={{ fontWeight: 700 }}
           >
-            <p className="text-[10px] md:text-xs font-bold tracking-[0.3em] uppercase text-[#8cc63f] mb-3">
-              Projects
-            </p>
-            <h1 className="text-4xl md:text-6xl font-black text-slate-900 mb-8">
-              制作物
-            </h1>
-          </motion.div>
+            作品紹介
+          </motion.h1>
+          <motion.p
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.8, delay: 0.2 }}
+            className="text-xl text-white/90"
+          >
+            Digitartメンバーが生み出したプロジェクトの数々
+          </motion.p>
         </div>
       </section>
 
       {/* Intro */}
-      <section className="py-16 px-6">
+      <section className="py-20 px-6">
         <div className="max-w-4xl mx-auto text-center">
           <motion.p
-            initial={{ opacity: 0, y: 20 }}
+            initial={{ opacity: 0, y: 30 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.7 }}
-            className="text-lg md:text-xl text-slate-600 leading-relaxed font-medium"
+            transition={{ duration: 0.8 }}
+            className="text-lg text-gray-600 leading-relaxed"
           >
             プログラミング、デザイン、ハードウェアを横断するメンバーたちが、
+            <br className="hidden md:block" />
             チームで生み出したプロジェクトの数々をご紹介します。
           </motion.p>
         </div>

--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -23,10 +23,10 @@ export default function JoinPage() {
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.8 }}
           >
-            <p className="text-[10px] md:text-xs font-bold tracking-[0.3em] text-[#8cc63f] mb-3">
-              入会案内
+            <p className="text-[10px] md:text-xs font-bold tracking-[0.3em] uppercase text-[#8cc63f] mb-3">
+            Welcome
             </p>
-            <h1 className="text-4xl md:text-6xl font-black text-slate-900 leading-tight mb-8">
+            <h1 className="text-5xl md:text-7xl font-black text-slate-900 leading-tight mb-8">
               Join Us
             </h1>
             <p className="text-base md:text-lg text-slate-600 leading-relaxed max-w-2xl mx-auto font-medium">

--- a/app/news/articles/2026-04-22-yamanotewalk.md
+++ b/app/news/articles/2026-04-22-yamanotewalk.md
@@ -3,7 +3,7 @@ title: "歩いて山手線を一周した話"
 date: "2026-04-24"
 author: "くろむ"
 excerpt: "渋谷発で山手線を徒歩一周した記録。道中の思い出を振り返ります。"
-category: "colum"
+category: "column"
 ---
 
 ## はじめに  


### PR DESCRIPTION
about以下の各ページにおいて、ページ頭のデザインを統一化
<img width="400" alt="スクリーンショット 2026-04-24 182730" src="https://github.com/user-attachments/assets/0e05d3d1-1663-4f4b-996d-6e5d913396e2" /><img width="400" alt="スクリーンショット 2026-04-24 182654" src="https://github.com/user-attachments/assets/e0c473c7-0868-447d-9daf-d321f7d41053" />
<img width="400" alt="スクリーンショット 2026-04-24 182745" src="https://github.com/user-attachments/assets/e2d9ed0b-4907-4334-a469-c17edbbb09ae" /><img width="400" alt="スクリーンショット 2026-04-24 182752" src="https://github.com/user-attachments/assets/2ac31237-93f2-425f-99ff-55fdf204616f" />
<img width="400" alt="スクリーンショット 2026-04-24 182800" src="https://github.com/user-attachments/assets/4dea9178-251a-46e3-9096-e7310e90d49f" /><img width="400" alt="スクリーンショット 2026-04-24 182807" src="https://github.com/user-attachments/assets/259c4dc7-e46d-4c6c-92aa-282139668e80" />
