### PR TITLE
feat: GUI上での記事執筆システムの導入

### DIFF
--- a/.github/workflows/rotate-password.yml
+++ b/.github/workflows/rotate-password.yml
@@ -1,0 +1,50 @@
+name: Rotate Admin Password
+
+on:
+  schedule:
+    - cron: '0 0 * * 0' # 毎週日曜0時(UTC)に実行
+  workflow_dispatch: # 手動実行も可能にする
+
+jobs:
+  rotate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Random Password
+        id: gen
+        run: |
+          PWD=$(openssl rand -base64 9)
+          echo "::add-mask::$PWD"
+          echo "new_pwd=$PWD" >> $GITHUB_OUTPUT
+
+      - name: Update Cloudflare Pages Env Var
+        env:
+          CF_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PROJECT_NAME: "digitart-hp" # Cloudflare上のプロジェクト名
+        run: |
+          # 1. 現在の設定を取得
+          curl -s -X GET "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/pages/projects/${PROJECT_NAME}" \
+               -H "Authorization: Bearer ${CF_TOKEN}" > project.json
+
+          # 2. ADMIN_PASSWORD だけ上書き
+          NEW_PWD="${{ steps.gen.outputs.new_pwd }}"
+          jq --arg pwd "$NEW_PWD" '.result.deployment_configs.production.env_vars.ADMIN_PASSWORD.value = $pwd | .result.deployment_configs.preview.env_vars.ADMIN_PASSWORD.value = $pwd' project.json > temp.json
+          jq '{deployment_configs: .result.deployment_configs}' temp.json > patch.json
+
+          # 3. 更新
+          curl -s -X PATCH "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/pages/projects/${PROJECT_NAME}" \
+               -H "Authorization: Bearer ${CF_TOKEN}" \
+               -H "Content-Type: application/json" \
+               -d @patch.json
+
+          # 4. 新しいパスワードを反映させるための再デプロイ
+          curl -s -X POST "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/pages/projects/${PROJECT_NAME}/deployments" \
+               -H "Authorization: Bearer ${CF_TOKEN}"
+
+      - name: Notify Discord
+        env:
+          WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK }}
+        run: |
+          curl -H "Content-Type: application/json" \
+               -d "{\"content\": \"**管理画面パスワードを更新しました**\nパスワード: \`${{ steps.gen.outputs.new_pwd }}\`\"}" \
+               $WEBHOOK_URL

--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -1,0 +1,105 @@
+'use server';
+
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { createPullRequestForArticle } from '@/lib/github';
+
+export async function loginAction(prevState: any, formData: FormData) {
+  const password = formData.get('password') as string;
+  const adminPassword = process.env.ADMIN_PASSWORD;
+
+  if (!adminPassword) {
+    return { error: 'サーバーで ADMIN_PASSWORD が設定されていません。' };
+  }
+
+  if (password === adminPassword) {
+    const cookieStore = await cookies();
+    cookieStore.set('admin_auth', 'true', {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      maxAge: 60 * 60 * 24 * 7, // 1 week
+      path: '/',
+    });
+    redirect('/admin/news/new');
+  } else {
+    return { error: 'パスワードが正しくありません。' };
+  }
+}
+
+export async function publishArticleAction(prevState: any, formData: FormData) {
+  const cookieStore = await cookies();
+  const authCookie = cookieStore.get('admin_auth');
+  if (!authCookie || authCookie.value !== 'true') {
+    return { error: '認証されていません。' };
+  }
+
+  try {
+    const title = formData.get('title') as string;
+    const author = formData.get('author') as string;
+    const date = formData.get('date') as string;
+    const category = formData.get('category') as string;
+    const excerpt = formData.get('excerpt') as string;
+    const content = formData.get('content') as string;
+    const slugInput = formData.get('slug') as string;
+    const imagesJson = formData.get('images') as string;
+    
+    if (!title || !author || !date || !category || !content || !slugInput) {
+      return { error: '必須項目が入力されていません。' };
+    }
+
+    if (!/^[a-z0-9-]+$/.test(slugInput)) {
+      return { error: 'ファイル名は半角英小文字、数字、ハイフンのみ使用可能です。' };
+    }
+
+    const allImages: { path: string, content: string }[] = imagesJson ? JSON.parse(imagesJson) : [];
+    
+    // Markdown本文にパスが含まれている画像のみを抽出（エディタ上で削除された画像を除外）
+    const images = allImages.filter(img => {
+      const markdownPath = img.path.replace(/^public/, '');
+      return content.includes(markdownPath);
+    });
+
+    // Format Frontmatter
+    const frontmatter = `---
+title: "${title}"
+date: "${date}"
+author: "${author}"
+excerpt: "${excerpt || ''}"
+category: "${category}"
+---
+
+${content}
+`;
+
+    // Prepare files for GitHub
+    const finalSlug = `${date}-${slugInput}`;
+    const mdPath = `app/news/articles/${finalSlug}.md`;
+
+    const githubFiles = [
+      {
+        path: mdPath,
+        content: frontmatter,
+        encoding: 'utf-8' as const,
+      }
+    ];
+
+    // Add images
+    for (const img of images) {
+      githubFiles.push({
+        path: img.path, // e.g. public/images/articles/YYYY-MM-DD/filename.png
+        content: img.content, // base64 string without data URL prefix
+        encoding: 'base64' as const,
+      });
+    }
+
+    // GitHubにPRを作成
+    const branchName = `digitart/article-${date}-${Date.now()}`;
+    const commitMessage = `add: 記事「${title}」を追加`;
+    const prUrl = await createPullRequestForArticle(githubFiles, commitMessage, branchName);
+
+    return { success: true, prUrl };
+  } catch (error: any) {
+    console.error('Failed to publish article:', error);
+    return { error: error.message || '記事の公開に失敗しました。' };
+  }
+}

--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -26,11 +26,17 @@ export async function loginAction(prevState: any, formData: FormData) {
   }
 }
 
-export async function publishArticleAction(prevState: any, formData: FormData) {
+export type ActionState = {
+  error: string | null;
+  success: boolean;
+  prUrl: string | null;
+};
+
+export async function publishArticleAction(prevState: any, formData: FormData): Promise<ActionState> {
   const cookieStore = await cookies();
   const authCookie = cookieStore.get('admin_auth');
   if (!authCookie || authCookie.value !== 'true') {
-    return { error: '認証されていません。' };
+    return { error: '認証されていません。', success: false, prUrl: null };
   }
 
   try {
@@ -44,11 +50,11 @@ export async function publishArticleAction(prevState: any, formData: FormData) {
     const imagesJson = formData.get('images') as string;
     
     if (!title || !author || !date || !category || !content || !slugInput) {
-      return { error: '必須項目が入力されていません。' };
+      return { error: '必須項目が入力されていません。', success: false, prUrl: null };
     }
 
     if (!/^[a-z0-9-]+$/.test(slugInput)) {
-      return { error: 'ファイル名は半角英小文字、数字、ハイフンのみ使用可能です。' };
+      return { error: 'ファイル名は半角英小文字、数字、ハイフンのみ使用可能です。', success: false, prUrl: null };
     }
 
     const allImages: { path: string, content: string }[] = imagesJson ? JSON.parse(imagesJson) : [];
@@ -75,11 +81,11 @@ ${content}
     const finalSlug = `${date}-${slugInput}`;
     const mdPath = `app/news/articles/${finalSlug}.md`;
 
-    const githubFiles = [
+    const githubFiles: { path: string; content: string; encoding: 'utf-8' | 'base64' }[] = [
       {
         path: mdPath,
         content: frontmatter,
-        encoding: 'utf-8' as const,
+        encoding: 'utf-8',
       }
     ];
 
@@ -97,9 +103,9 @@ ${content}
     const commitMessage = `add: 記事「${title}」を追加`;
     const prUrl = await createPullRequestForArticle(githubFiles, commitMessage, branchName);
 
-    return { success: true, prUrl };
+    return { error: null, success: true, prUrl };
   } catch (error: any) {
     console.error('Failed to publish article:', error);
-    return { error: error.message || '記事の公開に失敗しました。' };
+    return { error: error.message || '記事の公開に失敗しました。', success: false, prUrl: null };
   }
 }

--- a/app/admin/news/login/page.tsx
+++ b/app/admin/news/login/page.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useActionState } from 'react';
+import { loginAction } from '@/app/admin/actions';
+import { Button } from '@/components/ui/button'; // fallback to simple button if not exists
+import { KeyRound } from 'lucide-react';
+
+const initialState = {
+  error: null as string | null,
+};
+
+export default function AdminLoginPage() {
+  const [state, formAction, isPending] = useActionState(loginAction, initialState);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-stone-100 px-4 relative overflow-hidden">
+      <div className="max-w-md w-full">
+        <div className="bg-white/95 backdrop-blur-md rounded-3xl shadow-2xl shadow-emerald-200/10 p-10 border border-white/50">
+          <div className="text-center mb-10">
+            <div className="inline-flex items-center justify-center w-20 h-20 rounded-2xl bg-emerald-50 text-emerald-600 mb-6 shadow-sm border border-emerald-100 rotate-3 hover:rotate-0 transition-transform duration-300">
+              <KeyRound size={40} />
+            </div>
+            <h1 className="text-3xl font-extrabold text-slate-900 tracking-tight">メンバー確認</h1>
+            <p className="text-slate-500 mt-3 font-medium">
+              Digitartのメンバーであることを確認するため、<br />
+              パスワードを入力してください。
+            </p>
+          </div>
+
+          <form action={formAction} className="space-y-8">
+            <div className="space-y-3">
+              <label htmlFor="password" className="block text-sm font-bold text-slate-700 ml-1">
+                パスワード
+              </label>
+              <input
+                type="password"
+                id="password"
+                name="password"
+                required
+                className="w-full px-5 py-4 rounded-2xl border border-slate-200 bg-white/50 text-slate-900 focus:ring-4 focus:ring-emerald-500/10 focus:border-emerald-500 outline-none transition-all placeholder:text-slate-300"
+                placeholder="••••••••"
+              />
+            </div>
+
+            {state?.error && (
+              <div className="p-4 bg-red-50 border border-red-100 text-red-600 text-sm font-bold rounded-2xl flex items-center gap-3">
+                <span className="w-1.5 h-1.5 rounded-full bg-red-500"></span>
+                {state.error}
+              </div>
+            )}
+
+            <button
+              type="submit"
+              disabled={isPending}
+              className="w-full py-4 px-6 bg-emerald-600 hover:bg-emerald-500 text-white font-bold rounded-2xl shadow-lg shadow-emerald-200 transition-all hover:-translate-y-0.5 active:translate-y-0 disabled:opacity-70 disabled:cursor-not-allowed flex items-center justify-center gap-2 group"
+            >
+              {isPending ? (
+                <>
+                  <div className="w-5 h-5 border-2 border-white/30 border-t-white rounded-full animate-spin"></div>
+                  <span>認証中...</span>
+                </>
+              ) : (
+                <>
+                  <span>次へ</span>
+                  <svg className="w-5 h-5 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M13 7l5 5m0 0l-5 5m5-5H6" />
+                  </svg>
+                </>
+              )}
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/admin/news/login/page.tsx
+++ b/app/admin/news/login/page.tsx
@@ -2,7 +2,6 @@
 
 import { useActionState } from 'react';
 import { loginAction } from '@/app/admin/actions';
-import { Button } from '@/components/ui/button'; // fallback to simple button if not exists
 import { KeyRound } from 'lucide-react';
 
 const initialState = {

--- a/app/admin/news/new/page.tsx
+++ b/app/admin/news/new/page.tsx
@@ -1,0 +1,328 @@
+'use client';
+
+import { useState, useRef, useActionState, FormEvent } from 'react';
+import { publishArticleAction } from '@/app/admin/actions';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import remarkMath from 'remark-math';
+import rehypeKatex from 'rehype-katex';
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import { ImagePlus, Send, Loader2 } from 'lucide-react';
+import 'katex/dist/katex.min.css';
+
+const initialState = {
+  error: null as string | null,
+  success: false as boolean,
+  prUrl: null as string | null,
+};
+
+export default function AdminNewsEditor() {
+  const [state, formAction, isPending] = useActionState(publishArticleAction, initialState);
+  
+  const [title, setTitle] = useState('');
+  const [author, setAuthor] = useState('');
+  const [date, setDate] = useState(new Date().toISOString().split('T')[0]);
+  const [slug, setSlug] = useState('');
+  const [category, setCategory] = useState('column');
+  const [excerpt, setExcerpt] = useState('');
+  const [content, setContent] = useState('');
+  const [images, setImages] = useState<{ path: string; content: string }[]>([]);
+
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Handle image upload via file input or drag & drop
+  const handleImageUpload = (file: File) => {
+    if (!file.type.startsWith('image/')) return;
+
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const base64Data = e.target?.result as string;
+      const base64Content = base64Data.split(',')[1]; // Remove data URL prefix
+      
+      const fileName = `${Date.now()}-${file.name.replace(/[^a-zA-Z0-9.-]/g, '_')}`;
+      const imagePath = `public/images/articles/${date}/${fileName}`;
+      const imageMarkdownUrl = `/images/articles/${date}/${fileName}`;
+
+      setImages((prev) => [...prev, { path: imagePath, content: base64Content }]);
+
+      // Insert markdown into textarea
+      const imageMarkdown = `\n![${file.name}](${imageMarkdownUrl})\n`;
+      if (textareaRef.current) {
+        const start = textareaRef.current.selectionStart;
+        const end = textareaRef.current.selectionEnd;
+        const newContent = content.substring(0, start) + imageMarkdown + content.substring(end);
+        setContent(newContent);
+        
+        // Reset cursor
+        setTimeout(() => {
+          if (textareaRef.current) {
+            textareaRef.current.selectionStart = start + imageMarkdown.length;
+            textareaRef.current.selectionEnd = start + imageMarkdown.length;
+            textareaRef.current.focus();
+          }
+        }, 0);
+      } else {
+        setContent((prev) => prev + imageMarkdown);
+      }
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const handlePaste = (e: React.ClipboardEvent) => {
+    if (e.clipboardData.files.length > 0) {
+      e.preventDefault();
+      handleImageUpload(e.clipboardData.files[0]);
+    }
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    if (e.dataTransfer.files.length > 0) {
+      handleImageUpload(e.dataTransfer.files[0]);
+    }
+  };
+
+  if (state?.success) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center bg-stone-50 px-4">
+        <div className="text-center space-y-6 max-w-md">
+          <div className="inline-flex w-20 h-20 bg-emerald-100 text-emerald-600 rounded-3xl items-center justify-center mx-auto mb-4 rotate-3 shadow-sm border border-emerald-200">
+            <Send size={36} />
+          </div>
+          <h1 className="text-3xl font-extrabold text-slate-900 tracking-tight">リクエストを送信しました！</h1>
+          <p className="text-slate-500 font-medium leading-relaxed">
+            記事の追加リクエスト（Pull Request）が作成されました。<br />
+            管理者が確認・承認するとサイトに反映されます。
+          </p>
+          {state.prUrl && (
+            <a
+              href={state.prUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-emerald-600 hover:text-emerald-700 font-bold underline underline-offset-4 block mt-4"
+            >
+              <span title="Organizationへのアクセス権が必要です">作成されたPull Requestを確認する</span>
+            </a>
+          )}
+          <button
+            onClick={() => window.location.reload()}
+            className="mt-6 px-8 py-3 bg-emerald-600 hover:bg-emerald-500 text-white rounded-2xl font-bold shadow-lg shadow-emerald-200 transition-all hover:-translate-y-0.5"
+          >
+            続けて別の記事を書く
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-stone-50 flex flex-col">
+      <header className="border-b border-slate-200 bg-white/80 backdrop-blur-md px-6 py-4 flex items-center justify-between sticky top-0 z-10 flex-nowrap gap-4">
+        <h1 className="text-2xl font-bold text-slate-900 flex items-center gap-2 whitespace-nowrap shrink-0">
+          記事の新規作成
+        </h1>
+        <div className="flex items-center gap-4 min-w-0">
+          {state?.error && (
+            <span className="text-red-500 text-sm font-bold bg-red-50 px-3 py-1 rounded-full border border-red-100 truncate max-w-md" title={state.error}>
+              {state.error}
+            </span>
+          )}
+          <button
+            onClick={() => {
+              const form = document.getElementById('publish-form') as HTMLFormElement;
+              if (form) form.requestSubmit();
+            }}
+            disabled={isPending}
+            className="flex items-center gap-2 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 text-white px-6 py-2.5 rounded-xl font-bold shadow-lg shadow-emerald-200 transition-all hover:-translate-y-0.5 active:translate-y-0 whitespace-nowrap shrink-0"
+          >
+            {isPending ? <Loader2 className="animate-spin" size={20} /> : <Send size={20} />}
+            {isPending ? '送信中...' : '追加リクエストを送信'}
+          </button>
+        </div>
+      </header>
+
+      <form id="publish-form" action={formAction} className="hidden">
+        <input type="hidden" name="title" value={title} />
+        <input type="hidden" name="slug" value={slug} />
+        <input type="hidden" name="author" value={author} />
+        <input type="hidden" name="date" value={date} />
+        <input type="hidden" name="category" value={category} />
+        <input type="hidden" name="excerpt" value={excerpt} />
+        <input type="hidden" name="content" value={content} />
+        <input type="hidden" name="images" value={JSON.stringify(images)} />
+      </form>
+
+      <div className="flex flex-1 overflow-hidden h-[calc(100vh-73px)]">
+        {/* Left Side: Editor */}
+        <div className="w-1/2 flex flex-col border-r border-slate-200 bg-stone-50">
+          <div className="p-6 overflow-y-auto space-y-5 border-b border-slate-200 bg-white/30">
+            <div className="grid grid-cols-2 gap-5">
+              <div>
+                <label className="block text-xs font-bold text-slate-400 uppercase tracking-widest mb-1.5 ml-1">タイトル</label>
+                <input
+                  type="text"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  className="w-full px-4 py-2.5 border border-slate-200 rounded-xl bg-white text-slate-900 focus:ring-4 focus:ring-emerald-500/10 focus:border-emerald-500 outline-none transition-all"
+                  placeholder="記事のタイトル"
+                  required
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-bold text-slate-400 uppercase tracking-widest mb-1.5 ml-1">著者</label>
+                <input
+                  type="text"
+                  value={author}
+                  onChange={(e) => setAuthor(e.target.value)}
+                  className="w-full px-4 py-2.5 border border-slate-200 rounded-xl bg-white text-slate-900 focus:ring-4 focus:ring-emerald-500/10 focus:border-emerald-500 outline-none transition-all"
+                  placeholder="Discord名"
+                  required
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-bold text-slate-400 uppercase tracking-widest mb-1.5 ml-1">公開日</label>
+                <input
+                  type="date"
+                  value={date}
+                  onChange={(e) => setDate(e.target.value)}
+                  className="w-full px-4 py-2.5 border border-slate-200 rounded-xl bg-white text-slate-900 focus:ring-4 focus:ring-emerald-500/10 focus:border-emerald-500 outline-none transition-all"
+                  required
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-bold text-slate-400 uppercase tracking-widest mb-1.5 ml-1">カテゴリ</label>
+                <select
+                  value={category}
+                  onChange={(e) => setCategory(e.target.value)}
+                  className="w-full px-4 py-2.5 border border-slate-200 rounded-xl bg-white text-slate-900 focus:ring-4 focus:ring-emerald-500/10 focus:border-emerald-500 outline-none transition-all appearance-none"
+                >
+                  <option value="notice">お知らせ</option>
+                  <option value="column">コラム</option>
+                </select>
+              </div>
+              <div className="col-span-2">
+                <label className="block text-xs font-bold text-slate-400 uppercase tracking-widest mb-1.5 ml-1">
+                  ファイル名（URLの一部になります） <span className="text-red-400">*</span>
+                </label>
+                <div className="flex items-center">
+                  <span className="px-4 py-2.5 bg-slate-100 border border-r-0 border-slate-200 rounded-l-xl text-slate-500 font-mono text-sm">
+                    {date}-
+                  </span>
+                  <input
+                    type="text"
+                    value={slug}
+                    onChange={(e) => setSlug(e.target.value)}
+                    pattern="^[a-z0-9-]+$"
+                    title="半角英小文字、数字、ハイフンのみ使用できます"
+                    className="flex-1 px-4 py-2.5 border border-slate-200 rounded-r-xl bg-white text-slate-900 focus:ring-4 focus:ring-emerald-500/10 focus:border-emerald-500 outline-none transition-all font-mono"
+                    placeholder="snake-case-title"
+                    required
+                  />
+                  <span className="ml-2 text-slate-500 font-mono text-sm">.md</span>
+                </div>
+                <p className="mt-1.5 ml-1 text-xs text-slate-400 font-medium">半角英小文字、数字、ハイフンのみ使用可能</p>
+              </div>
+              <div className="col-span-2">
+                <label className="block text-xs font-bold text-slate-400 uppercase tracking-widest mb-1.5 ml-1">概要</label>
+                <textarea
+                  value={excerpt}
+                  onChange={(e) => setExcerpt(e.target.value)}
+                  className="w-full px-4 py-2.5 border border-slate-200 rounded-xl bg-white text-slate-900 focus:ring-4 focus:ring-emerald-500/10 focus:border-emerald-500 outline-none transition-all resize-none"
+                  rows={2}
+                  placeholder="ニュース一覧に表示される概要文"
+                />
+              </div>
+            </div>
+          </div>
+          
+          <div className="flex-1 relative flex flex-col bg-amber-50/60">
+            <div className="absolute top-4 right-4 flex items-center gap-2 z-10">
+              <label className="cursor-pointer bg-white/80 backdrop-blur-sm border border-slate-200 text-slate-500 p-2.5 rounded-xl hover:bg-white hover:text-emerald-600 transition-all shadow-sm group" title="画像を挿入">
+                <ImagePlus size={20} className="group-hover:scale-110 transition-transform" />
+                <input
+                  type="file"
+                  accept="image/*"
+                  className="hidden"
+                  onChange={(e) => {
+                    if (e.target.files?.[0]) handleImageUpload(e.target.files[0]);
+                  }}
+                />
+              </label>
+            </div>
+            <textarea
+              ref={textareaRef}
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              onPaste={handlePaste}
+              onDrop={handleDrop}
+              onDragOver={(e) => e.preventDefault()}
+              className="flex-1 w-full p-8 bg-transparent text-slate-800 outline-none resize-none font-mono text-sm leading-relaxed"
+              placeholder="ここにMarkdownで記事を書いてください... (画像はドラッグ＆ドロップや貼り付けで挿入できます)"
+              required
+            />
+          </div>
+        </div>
+
+        {/* Right Side: Preview */}
+        <div className="w-1/2 bg-white overflow-y-auto p-10 max-w-none shadow-inner border-l border-slate-100">
+          <ReactMarkdown
+            remarkPlugins={[remarkGfm, remarkMath]}
+            rehypePlugins={[rehypeKatex]}
+            components={{
+              h1: ({node, ...props}) => <h1 className="text-2xl md:text-3xl font-extrabold text-slate-900 mt-6 mb-4 pb-3 border-b-2 border-slate-100" {...props} />,
+              h2: ({node, ...props}) => <h2 className="text-xl md:text-2xl font-bold text-slate-900 mt-8 mb-3 pb-2 border-b border-slate-100" {...props} />,
+              h3: ({node, ...props}) => <h3 className="text-lg md:text-xl font-bold text-slate-900 mt-6 mb-3 flex items-center gap-2" {...props}><span className="w-1.5 h-6 bg-emerald-500 rounded-full inline-block"></span>{props.children}</h3>,
+              p: ({node, ...props}) => <p className="leading-relaxed text-slate-700 font-medium mb-5 text-base" {...props} />,
+              a: ({ node, href, children, ...props }) => {
+                const linkClass = "text-emerald-600 hover:text-emerald-700 underline underline-offset-4 decoration-emerald-200 hover:decoration-emerald-500 transition-all font-bold";
+                return <a href={href} className={linkClass} target="_blank" rel="noopener noreferrer" {...props}>{children}</a>;
+              },
+              ul: ({node, ...props}) => <ul className="list-disc list-outside ml-6 mb-5 space-y-1.5 text-slate-700 font-medium marker:text-emerald-500" {...props} />,
+              ol: ({node, ...props}) => <ol className="list-decimal list-outside ml-6 mb-5 space-y-1.5 text-slate-700 font-medium font-mono marker:text-emerald-600" {...props} />,
+              li: ({node, ...props}) => <li className="pl-1 leading-relaxed text-slate-700" {...props} />,
+              blockquote: ({node, ...props}) => <blockquote className="border-l-4 border-emerald-400 pl-4 py-1.5 my-4 bg-emerald-50/50 rounded-r-xl italic text-slate-600 font-medium" {...props} />,
+              code: ({node, className, children, ...props}: any) => {
+                const match = /language-(\w+)/.exec(className || '');
+                return match ? (
+                  <SyntaxHighlighter
+                    {...props}
+                    style={vscDarkPlus as any}
+                    language={match[1]}
+                    PreTag="div"
+                  >
+                    {String(children).replace(/\n$/, '')}
+                  </SyntaxHighlighter>
+                ) : (
+                  <code className="bg-slate-100 text-slate-800 px-2 py-1 rounded-md text-sm font-mono border border-slate-200 break-words" {...props}>
+                    {children}
+                  </code>
+                )
+              },
+              img: ({node, alt, src, ...props}) => {
+                // If it's a dropped image, src might be a local path that hasn't been uploaded. 
+                // We show base64 content instead if we have it in our state.
+                const imgState = images.find(img => img.path === 'public' + src);
+                const actualSrc = imgState ? `data:image/png;base64,${imgState.content}` : src;
+                
+                return (
+                  <span className="block w-fit max-w-full my-10 mx-auto rounded-2xl overflow-hidden shadow-md border border-slate-200">
+                    <img 
+                      className="max-w-full w-auto max-h-96 h-auto object-cover !m-0" 
+                      src={actualSrc}
+                      alt={alt || '記事内画像'} 
+                      {...props} 
+                    />
+                  </span>
+                );
+              },
+              hr: ({node, ...props}) => <hr className="my-10 border-t-2 border-slate-100 border-dashed" {...props} />
+            }}
+          >
+            {content || '*ここにプレビューが表示されます...*'}
+          </ReactMarkdown>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/admin/news/new/page.tsx
+++ b/app/admin/news/new/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useRef, useActionState, FormEvent } from 'react';
-import { publishArticleAction } from '@/app/admin/actions';
+import { publishArticleAction, ActionState } from '@/app/admin/actions';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
@@ -11,10 +11,10 @@ import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { ImagePlus, Send, Loader2 } from 'lucide-react';
 import 'katex/dist/katex.min.css';
 
-const initialState = {
-  error: null as string | null,
-  success: false as boolean,
-  prUrl: null as string | null,
+const initialState: ActionState = {
+  error: null,
+  success: false,
+  prUrl: null,
 };
 
 export default function AdminNewsEditor() {

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -1,7 +1,16 @@
+"use client";
+
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { SITE_NAME, SOCIAL_LINKS, NAV_LINKS } from "@/lib/constants";
 
 export default function Footer() {
+  const pathname = usePathname();
+
+  // Adminページではフッターを表示しない
+  if (pathname?.startsWith('/admin')) {
+    return null;
+  }
   const year = new Date().getFullYear();
   // 左列に Home と About を固定配置し、残りを右列に配置する
   const leftKeys = ["/", "/about"];

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -10,6 +10,11 @@ export default function Header() {
   const [isOpen, setIsOpen] = useState(false);
   const [openGroups, setOpenGroups] = useState<Record<string, boolean>>({});
   const pathname = usePathname();
+  
+  // Adminページではヘッダーを表示しない
+  if (pathname?.startsWith('/admin')) {
+    return null;
+  }
 
   const [isScrolled, setIsScrolled] = useState(false);
   useEffect(() => {

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1,0 +1,120 @@
+export async function createPullRequestForArticle(
+  files: { path: string; content: string; encoding: 'utf-8' | 'base64' }[],
+  commitMessage: string,
+  branchName: string
+) {
+  const token = process.env.GITHUB_TOKEN;
+  const owner = process.env.GITHUB_OWNER;
+  const repo = process.env.GITHUB_REPO;
+  const baseBranch = process.env.GITHUB_BRANCH || 'main';
+
+  if (!token || !owner || !repo) {
+    throw new Error('GitHubの設定が見つかりません。環境変数 GITHUB_TOKEN, GITHUB_OWNER, GITHUB_REPO を設定してください。');
+  }
+
+  const baseUrl = `https://api.github.com/repos/${owner}/${repo}`;
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github.v3+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+
+  // 1. Get the current reference of the base branch (main)
+  const refRes = await fetch(`${baseUrl}/git/ref/heads/${baseBranch}`, { headers });
+  if (!refRes.ok) throw new Error(`ブランチ情報の取得に失敗しました: ${await refRes.text()}`);
+  const refData = await refRes.json();
+  const latestCommitSha = refData.object.sha;
+
+  // 2. Create a new branch from the base branch
+  const createBranchRes = await fetch(`${baseUrl}/git/refs`, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      ref: `refs/heads/${branchName}`,
+      sha: latestCommitSha,
+    }),
+  });
+  if (!createBranchRes.ok) throw new Error(`新しいブランチの作成に失敗しました: ${await createBranchRes.text()}`);
+
+  // 3. Get the commit data to find the tree SHA
+  const commitRes = await fetch(`${baseUrl}/git/commits/${latestCommitSha}`, { headers });
+  if (!commitRes.ok) throw new Error(`最新コミットの取得に失敗しました: ${await commitRes.text()}`);
+  const commitData = await commitRes.json();
+  const baseTreeSha = commitData.tree.sha;
+
+  // 4. Create Blobs for each file and build the tree array
+  const tree = [];
+  for (const file of files) {
+    const blobRes = await fetch(`${baseUrl}/git/blobs`, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        content: file.content,
+        encoding: file.encoding,
+      }),
+    });
+    if (!blobRes.ok) throw new Error(`ファイルのアップロード(blob作成)に失敗しました (${file.path}): ${await blobRes.text()}`);
+    const blobData = await blobRes.json();
+    tree.push({
+      path: file.path,
+      mode: '100644', // File mode
+      type: 'blob',
+      sha: blobData.sha,
+    });
+  }
+
+  // 5. Create a new Tree
+  const newTreeRes = await fetch(`${baseUrl}/git/trees`, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      base_tree: baseTreeSha,
+      tree: tree,
+    }),
+  });
+  if (!newTreeRes.ok) throw new Error(`ツリーの作成に失敗しました: ${await newTreeRes.text()}`);
+  const newTreeData = await newTreeRes.json();
+  const newTreeSha = newTreeData.sha;
+
+  // 6. Create a new Commit
+  const newCommitRes = await fetch(`${baseUrl}/git/commits`, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      message: commitMessage,
+      tree: newTreeSha,
+      parents: [latestCommitSha],
+    }),
+  });
+  if (!newCommitRes.ok) throw new Error(`コミットの作成に失敗しました: ${await newCommitRes.text()}`);
+  const newCommitData = await newCommitRes.json();
+  const newCommitSha = newCommitData.sha;
+
+  // 7. Update the reference of the new branch
+  const updateRefRes = await fetch(`${baseUrl}/git/refs/heads/${branchName}`, {
+    method: 'PATCH',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      sha: newCommitSha,
+      force: true,
+    }),
+  });
+  if (!updateRefRes.ok) throw new Error(`ブランチ参照の更新に失敗しました: ${await updateRefRes.text()}`);
+
+  // 8. Create a Pull Request
+  const prRes = await fetch(`${baseUrl}/pulls`, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      title: commitMessage,
+      head: branchName,
+      base: baseBranch,
+      body: `/admin/news/new より、記事「${commitMessage.replace('add: 記事「', '').replace('」を追加', '')}」の追加リクエストが作成されました。\n\n内容を確認し、問題なければマージしてください。`,
+    }),
+  });
+  if (!prRes.ok) throw new Error(`プルリクエストの作成に失敗しました: ${await prRes.text()}`);
+  const prData = await prRes.json();
+
+  return prData.html_url; // Return PR URL if needed
+}
+

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  // We only protect /admin and its subroutes
+  if (request.nextUrl.pathname.startsWith('/admin')) {
+    // If it's the login page, let them through
+    if (request.nextUrl.pathname === '/admin/news/login') {
+      return NextResponse.next();
+    }
+
+    const authCookie = request.cookies.get('admin_auth');
+    
+    // If not authenticated, redirect to login
+    if (!authCookie || authCookie.value !== 'true') {
+      return NextResponse.redirect(new URL('/admin/news/login', request.url));
+    }
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/admin/:path*'],
+};

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,11 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  experimental: {
+    serverActions: {
+      bodySizeLimit: '50mb',
+    },
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## 概要
サイト上から直接ニュース記事を作成・投稿できる機能を追加
Gitに不慣れなメンバーでも、UIからマークダウンや画像をブラウザ上で作成し、安全にPRを作成できる仕組みを構築しています。

## 追加・変更された仕様

### 1. 記事作成エディタの追加
*   **アクセスパス**: `/admin/news/login` から共通パスワードで認証後、`/admin/news/new` にアクセス。
*   **ライブプレビュー対応**: マークダウン形式で入力し、本番環境と全く同じスタイルのプレビューを横に表示しながら執筆可能。
*   **画像のドラッグ＆ドロップ**: エディタ上に画像を直接ドラッグ＆ドロップ（またはコピペ）することで、自動的にマークダウンが挿入されます。
*   **UI/UXの調整**: サイト全体の共通ヘッダー・フッターを管理画面では非表示にし、目に優しいオフホワイト基調のデザインで統一しています。

### 2. ファイル名（URL）のカスタム機能
*   自動生成ではなく、記事のURLになる「ファイル名（slug）」を `YYYY-MM-DD-{入力した文字}.md` の形式でユーザーが指定できるようにしました（半角英小文字・数字・ハイフンのみ許容）。

### 3. 未使用画像の自動クリーンアップ
*   エディタ上に画像をドロップしても、最終的なMarkdownテキスト内にその画像のパスが含まれていない場合（途中で消した場合など）は、裏側で自動的に除外してから送信される仕様です。

## システム設計
*   **認証**: Cloudflareの環境変数に設定されたパスワードで認証を行う。このパスワードはGitHubAction等で頻繁に書き換えたほうが安全性が高い（詳細は次のコメント）
*   **GitHub API 連携**: 
    1. 送信時にNext.jsのServer Action経由でベースブランチ（`main`）から新規ブランチ（`digitart/article-{date}-{timestamp}`）を作成。
    2. 記事のテキスト（`.md`）と画像（Base64からデコード）をBlobとしてアップロード。
    3. TreeとCommitを作成し、対象ブランチを更新。
    4. 自動で `main` へ向けたPull Requestを作成。
*   **データ上限の緩和**: 画像データをServer Actionで一度に送信するため、`next.config.ts` にて `bodySizeLimit: '50mb'` の拡張

## 実際に記事を投稿する手順
1. `https://www.digitart.jp/admin/news/login` へアクセスし、管理者パスワードを入力。
2. 記事エディタ画面で以下の必須項目を入力。
   - タイトル
   - 著者（Discord名など）
   - 公開日
   - カテゴリ（お知らせ・コラムなど）
   - ファイル名（URL用英小文字）
   - 概要（任意）
   - 記事本文（Markdown・画像ドロップ可能）
3. 右上の **「追加リクエストを送信」** ボタンをクリック。
4. 処理が成功するとPRが自動生成されるので、表示されたリンクからGitHubへ遷移し、管理者が内容を確認してmainへマージすることで本番環境へ反映

## 本番環境へ移行する際の注意点
Cloudflare Pages等の環境変数に以下を追加する必要がある
*   `ADMIN_PASSWORD` (管理画面のログインパスワード、GitHubActionで動的パスワードにする必要がある)
*   `GITHUB_TOKEN` (PR作成などの権限を持ったトークン、組織垢で生成する)
*   `GITHUB_OWNER` (digitart-tech-assoc)
*   `GITHUB_REPO` (Digitart_HP)